### PR TITLE
Namespace variables exposed to the browser

### DIFF
--- a/app/client/client.js
+++ b/app/client/client.js
@@ -70,10 +70,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // expose variables to browser
   if (__DEV__) {
-    window.store = store
-    window.React = React
-    window.ReactDOM = ReactDOM
-    window.Router = Router
-    window.history = history
+    window.playground = { history, store, React, ReactDOM, Router };
   }
 })


### PR DESCRIPTION
If you put all variables in directly on `window` you may find some odd issues, when something, generally a react component, needs, say, `React` present but the dev forgot to include them. Linting should warn about this but it's a good thing to prevent devs from those potential side-effects later on. Thoughts?
